### PR TITLE
State management and DRY refactor 

### DIFF
--- a/projects/mafia-frontend/package-lock.json
+++ b/projects/mafia-frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@algorandfoundation/algokit-utils": "^8.1.0",
         "@blockshake/defly-connect": "^1.2.1",
         "@perawallet/connect": "^1.4.1",
+        "@tanstack/react-query": "^5.74.3",
         "@txnlab/use-wallet": "^4.0.0",
         "@txnlab/use-wallet-react": "^4.0.0",
         "algoring-ts": "github:HashMapsData2Value/algoring-ts#main",
@@ -25,6 +26,7 @@
       "devDependencies": {
         "@algorandfoundation/algokit-client-generator": "^4.0.6",
         "@playwright/test": "^1.35.0",
+        "@tanstack/eslint-plugin-query": "^5.73.3",
         "@types/jest": "29.5.2",
         "@types/node": "^18.17.14",
         "@types/react": "^18.2.11",
@@ -2380,6 +2382,176 @@
       "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@tanstack/eslint-plugin-query": {
+      "version": "5.73.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/eslint-plugin-query/-/eslint-plugin-query-5.73.3.tgz",
+      "integrity": "sha512-GmUtnOkRzDuNOq96g3eW5ADKC1nWfrM9RI0kRyQVr87rOl6y+PUgkuVaPxh3R2C0EVODxCS07b9aaWphidl/OA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.18.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
+      }
+    },
+    "node_modules/@tanstack/eslint-plugin-query/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.30.0.tgz",
+      "integrity": "sha512-TTkN0Sjk3SxpfW3lvSteOUxcTxnviQKsD1wgf+sk30Aj7UrHjVNFPTosir3+/3eaxpRMau4U/NY6PAw6cmj7hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.30.0",
+        "@typescript-eslint/visitor-keys": "8.30.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@tanstack/eslint-plugin-query/node_modules/@typescript-eslint/types": {
+      "version": "8.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.30.0.tgz",
+      "integrity": "sha512-UQXFVF+8t4YhbU3nxabQL3/uyUEVw9kiVc+V0kZzblElC5MTvzvjJVhmrvI0xya1C1lqhIykWY7CeKioK9RMRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@tanstack/eslint-plugin-query/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.30.0.tgz",
+      "integrity": "sha512-/5n4GS/8koPkRx0XBl9OCFf9N80u+0h05QBU/z5cDBCUXnPpDmSzQ2FXC7JGvU777GOzE6mUAOx2ABtswgzWgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.30.0",
+        "@typescript-eslint/visitor-keys": "8.30.0",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.0.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@tanstack/eslint-plugin-query/node_modules/@typescript-eslint/utils": {
+      "version": "8.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.30.0.tgz",
+      "integrity": "sha512-TmrXlhwFWpfUBhJE7NJSyru26XrU/foccGTOFvLGcci38/ZnKXgq2IUtAUqE9ILVNjM4Zm3TccGuvl2QANhjag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "8.30.0",
+        "@typescript-eslint/types": "8.30.0",
+        "@typescript-eslint/typescript-estree": "8.30.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@tanstack/eslint-plugin-query/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.30.0.tgz",
+      "integrity": "sha512-oj82UQEi0fcYmpQpVISEOUM/icPNJiRh+E6svAtwNP58QpAQnnFigEoeGADm8H7t2bolxSb7+kRYzykbBdA47w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.30.0",
+        "eslint-visitor-keys": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@tanstack/eslint-plugin-query/node_modules/eslint-visitor-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@tanstack/eslint-plugin-query/node_modules/ts-api-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.74.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.74.3.tgz",
+      "integrity": "sha512-Mqk+5o3qTuAiZML248XpNH8r2cOzl15+LTbUsZQEwvSvn1GU4VQhvqzAbil36p+MBxpr/58oBSnRzhrBevDhfg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.74.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.74.3.tgz",
+      "integrity": "sha512-QrycUn0wxjVPzITvQvOxFRdhlAwIoOQSuav7qWD4SWCoKCdLbyRZ2vji2GuBq/glaxbF4wBx3fqcYRDOt8KDTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.74.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tanstack/react-store": {

--- a/projects/mafia-frontend/package.json
+++ b/projects/mafia-frontend/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@algorandfoundation/algokit-client-generator": "^4.0.6",
     "@playwright/test": "^1.35.0",
+    "@tanstack/eslint-plugin-query": "^5.73.3",
     "@types/jest": "29.5.2",
     "@types/node": "^18.17.14",
     "@types/react": "^18.2.11",
@@ -38,6 +39,7 @@
     "@algorandfoundation/algokit-utils": "^8.1.0",
     "@blockshake/defly-connect": "^1.2.1",
     "@perawallet/connect": "^1.4.1",
+    "@tanstack/react-query": "^5.74.3",
     "@txnlab/use-wallet": "^4.0.0",
     "@txnlab/use-wallet-react": "^4.0.0",
     "algoring-ts": "github:HashMapsData2Value/algoring-ts#main",

--- a/projects/mafia-frontend/src/App.tsx
+++ b/projects/mafia-frontend/src/App.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { SupportedWallet, WalletId, WalletManager, WalletProvider } from '@txnlab/use-wallet-react'
 import { SnackbarProvider } from 'notistack'
 import Home from './Home'
@@ -26,6 +27,7 @@ if (import.meta.env.VITE_ALGOD_NETWORK === 'localnet') {
   ]
 }
 
+const queryClient = new QueryClient()
 export default function App() {
   const algodConfig = getAlgodConfigFromViteEnvironment()
 
@@ -49,7 +51,9 @@ export default function App() {
   return (
     <SnackbarProvider maxSnack={3}>
       <WalletProvider manager={walletManager}>
-        <Home />
+        <QueryClientProvider client={queryClient}>
+          <Home />
+        </QueryClientProvider>
       </WalletProvider>
     </SnackbarProvider>
   )

--- a/projects/mafia-frontend/src/states/DawnStageDeadOrSaved.tsx
+++ b/projects/mafia-frontend/src/states/DawnStageDeadOrSaved.tsx
@@ -3,19 +3,16 @@ import { Player } from '../interfaces/player'
 
 interface DawnStageDeadOrSaveProps {
   playerObject: Player
-  refresher: () => void
 }
 
-const DawnStageDeadOrSave: React.FC<DawnStageDeadOrSaveProps> = ({ playerObject, refresher }) => {
+const DawnStageDeadOrSave: React.FC<DawnStageDeadOrSaveProps> = ({ playerObject }) => {
   const intervalRef = useRef<NodeJS.Timeout | null>(null)
 
   const startPolling = () => {
     if (intervalRef.current) {
       clearInterval(intervalRef.current)
     }
-    intervalRef.current = setInterval(() => {
-      refresher()
-    }, 2800) // Poll every 2.8 seconds
+    intervalRef.current = setInterval(() => {}, 2800) // Poll every 2.8 seconds
   }
 
   useEffect(() => {
@@ -27,9 +24,7 @@ const DawnStageDeadOrSave: React.FC<DawnStageDeadOrSaveProps> = ({ playerObject,
     }
   }, [])
 
-
   const handleDeadOrSave = async () => {
-
     const eliminateResults = await playerObject.day_client.send.dawnStageDeadOrSaved()
 
     console.log(eliminateResults)
@@ -40,10 +35,7 @@ const DawnStageDeadOrSave: React.FC<DawnStageDeadOrSaveProps> = ({ playerObject,
 
       <p>.</p>
 
-      <button
-        className="btn btn-primary"
-        onClick={() => handleDeadOrSave()}
-      >
+      <button className="btn btn-primary" onClick={() => handleDeadOrSave()}>
         <p>Someone must press the button to proceed.</p>
       </button>
     </div>

--- a/projects/mafia-frontend/src/states/DawnStageDoctorReveal.tsx
+++ b/projects/mafia-frontend/src/states/DawnStageDoctorReveal.tsx
@@ -1,16 +1,11 @@
-import algosdk from 'algosdk'
-import { randomBytes, createHash } from 'crypto'
-import { useState, useRef, useEffect } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Player } from '../interfaces/player'
-import { ZERO_ADDRESS } from '../utils/constants'
-import { ellipseAddress } from '../utils/ellipseAddress'
 
 interface DawnStageDoctorRevealProps {
   playerObject: Player
-  refresher: () => void
 }
 
-const DawnStageDoctorReveal: React.FC<DawnStageDoctorRevealProps> = ({ playerObject, refresher }) => {
+const DawnStageDoctorReveal: React.FC<DawnStageDoctorRevealProps> = ({ playerObject }) => {
   const [iAmDoctor, setIAmDoctor] = useState<boolean>(false)
   const intervalRef = useRef<NodeJS.Timeout | null>(null)
 
@@ -26,7 +21,6 @@ const DawnStageDoctorReveal: React.FC<DawnStageDoctorRevealProps> = ({ playerObj
       ]
 
       setIAmDoctor(playerObject.night_algo_address.addr.toString() === (await playerObject.night_client.state.global.doctor())!.toString())
-
     } catch (error) {
       console.error('Failed to fetch players:', error)
     }
@@ -36,9 +30,7 @@ const DawnStageDoctorReveal: React.FC<DawnStageDoctorRevealProps> = ({ playerObj
     if (intervalRef.current) {
       clearInterval(intervalRef.current)
     }
-    intervalRef.current = setInterval(() => {
-      refresher()
-    }, 2800) // Poll every 2.8 seconds
+    intervalRef.current = setInterval(() => {}, 2800) // Poll every 2.8 seconds
   }
 
   useEffect(() => {
@@ -56,7 +48,7 @@ const DawnStageDoctorReveal: React.FC<DawnStageDoctorRevealProps> = ({ playerObj
     await playerObject.night_client.send.dawnStageDoctorReveal({
       args: {
         patientAim: playerObject.target!,
-        blinder: playerObject.blinder!
+        blinder: playerObject.blinder!,
       },
     })
   }

--- a/projects/mafia-frontend/src/states/DawnStageMafiaReveal.tsx
+++ b/projects/mafia-frontend/src/states/DawnStageMafiaReveal.tsx
@@ -1,16 +1,11 @@
-import algosdk from 'algosdk'
-import { randomBytes, createHash } from 'crypto'
-import { useState, useRef, useEffect } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Player } from '../interfaces/player'
-import { ZERO_ADDRESS } from '../utils/constants'
-import { ellipseAddress } from '../utils/ellipseAddress'
 
 interface DawnStageMafiaRevealProps {
   playerObject: Player
-  refresher: () => void
 }
 
-const DawnStageMafiaReveal: React.FC<DawnStageMafiaRevealProps> = ({ playerObject, refresher }) => {
+const DawnStageMafiaReveal: React.FC<DawnStageMafiaRevealProps> = ({ playerObject }) => {
   const [iAmMafia, setIAmMafia] = useState<boolean>(false)
   const intervalRef = useRef<NodeJS.Timeout | null>(null)
 
@@ -26,7 +21,6 @@ const DawnStageMafiaReveal: React.FC<DawnStageMafiaRevealProps> = ({ playerObjec
       ]
 
       setIAmMafia(playerObject.night_algo_address.addr.toString() === (await playerObject.night_client.state.global.mafia())!.toString())
-
     } catch (error) {
       console.error('Failed to fetch players:', error)
     }
@@ -36,9 +30,7 @@ const DawnStageMafiaReveal: React.FC<DawnStageMafiaRevealProps> = ({ playerObjec
     if (intervalRef.current) {
       clearInterval(intervalRef.current)
     }
-    intervalRef.current = setInterval(() => {
-      refresher()
-    }, 2800) // Poll every 2.8 seconds
+    intervalRef.current = setInterval(() => {}, 2800) // Poll every 2.8 seconds
   }
 
   useEffect(() => {
@@ -56,7 +48,7 @@ const DawnStageMafiaReveal: React.FC<DawnStageMafiaRevealProps> = ({ playerObjec
     await playerObject.night_client.send.dawnStageMafiaReveal({
       args: {
         victimAim: playerObject.target!,
-        blinder: playerObject.blinder!
+        blinder: playerObject.blinder!,
       },
     })
   }

--- a/projects/mafia-frontend/src/states/DawnStageUnmasking.tsx
+++ b/projects/mafia-frontend/src/states/DawnStageUnmasking.tsx
@@ -1,15 +1,13 @@
-import { useEffect, useState, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Player } from '../interfaces/player'
 
 interface DawnStageUnmaskingProps {
   playerObject: Player
-  refresher: () => void
 }
 
-const DawnStageUnmasking: React.FC<DawnStageUnmaskingProps> = ({ playerObject, refresher }) => {
+const DawnStageUnmasking: React.FC<DawnStageUnmaskingProps> = ({ playerObject }) => {
   const [iAmEliminated, setIAmEliminated] = useState<boolean>(false)
   const intervalRef = useRef<NodeJS.Timeout | null>(null)
-
 
   const fetchElimiantedPlayers = async () => {
     const justElimiantedPlayer = await playerObject.day_client.state.global.justEliminatedPlayer()
@@ -17,14 +15,12 @@ const DawnStageUnmasking: React.FC<DawnStageUnmaskingProps> = ({ playerObject, r
     if (playerObject.day_algo_address.addr.toString() === justElimiantedPlayer) {
       setIAmEliminated(true)
     }
-
   }
 
   // Fetch the eliminated players from the contract
   useEffect(() => {
     fetchElimiantedPlayers()
   }, [])
-
 
   const handleDawnStageUnmasking = async () => {
     await playerObject.day_client
@@ -66,16 +62,14 @@ const DawnStageUnmasking: React.FC<DawnStageUnmaskingProps> = ({ playerObject, r
       .dummyOpUp({
         args: { i: 12 },
       })
-      .send();
+      .send()
   }
 
   const startPolling = () => {
     if (intervalRef.current) {
       clearInterval(intervalRef.current)
     }
-    intervalRef.current = setInterval(() => {
-      refresher()
-    }, 2800) // Poll every 2.8 seconds
+    intervalRef.current = setInterval(() => {}, 2800) // Poll every 2.8 seconds
   }
 
   useEffect(() => {
@@ -86,7 +80,6 @@ const DawnStageUnmasking: React.FC<DawnStageUnmaskingProps> = ({ playerObject, r
       }
     }
   }, [])
-
 
   return (
     <div>
@@ -103,10 +96,8 @@ const DawnStageUnmasking: React.FC<DawnStageUnmaskingProps> = ({ playerObject, r
       ) : (
         <p>Waiting for eliminated player to unmask themselves...</p>
       )}
-
     </div>
   )
-
 }
 
 export default DawnStageUnmasking

--- a/projects/mafia-frontend/src/states/DayStageEliminate.tsx
+++ b/projects/mafia-frontend/src/states/DayStageEliminate.tsx
@@ -1,35 +1,12 @@
-import React, { useEffect, useRef } from 'react'
+import React from 'react'
 import { Player } from '../interfaces/player'
 
 interface DayStageEliminateProps {
   playerObject: Player
-  refresher: () => void
 }
 
-const DayStageEliminate: React.FC<DayStageEliminateProps> = ({ playerObject, refresher }) => {
-  const intervalRef = useRef<NodeJS.Timeout | null>(null)
-
-  const startPolling = () => {
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current)
-    }
-    intervalRef.current = setInterval(() => {
-      refresher()
-    }, 2800) // Poll every 2.8 seconds
-  }
-
-  useEffect(() => {
-    startPolling()
-    return () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current) // Cleanup interval on component unmount
-      }
-    }
-  }, [])
-
-
+const DayStageEliminate: React.FC<DayStageEliminateProps> = ({ playerObject }) => {
   const handleEliminate = async () => {
-
     const eliminateResults = await playerObject.day_client.send.dayStageEliminate()
 
     console.log(eliminateResults)
@@ -40,10 +17,7 @@ const DayStageEliminate: React.FC<DayStageEliminateProps> = ({ playerObject, ref
 
       <p>You have finished voting.</p>
 
-      <button
-        className="btn btn-primary"
-        onClick={() => handleEliminate()}
-      >
+      <button className="btn btn-primary" onClick={() => handleEliminate()}>
         <p>Someone must press the button to proceed.</p>
       </button>
     </div>

--- a/projects/mafia-frontend/src/states/DayStageUnmasking.tsx
+++ b/projects/mafia-frontend/src/states/DayStageUnmasking.tsx
@@ -1,15 +1,13 @@
-import { useEffect, useState, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Player } from '../interfaces/player'
 
 interface DayStageUnmaskingProps {
   playerObject: Player
-  refresher: () => void
 }
 
-const DayStageUnmasking: React.FC<DayStageUnmaskingProps> = ({ playerObject, refresher }) => {
+const DayStageUnmasking: React.FC<DayStageUnmaskingProps> = ({ playerObject }) => {
   const [iAmEliminated, setIAmEliminated] = useState<boolean>(false)
   const intervalRef = useRef<NodeJS.Timeout | null>(null)
-
 
   const fetchElimiantedPlayers = async () => {
     const justElimiantedPlayer = await playerObject.day_client.state.global.justEliminatedPlayer()
@@ -17,14 +15,12 @@ const DayStageUnmasking: React.FC<DayStageUnmaskingProps> = ({ playerObject, ref
     if (playerObject.day_algo_address.addr.toString() === justElimiantedPlayer) {
       setIAmEliminated(true)
     }
-
   }
 
   // Fetch the eliminated players from the contract
   useEffect(() => {
     fetchElimiantedPlayers()
   }, [])
-
 
   const handleDayStageUnmasking = async () => {
     await playerObject.day_client
@@ -66,27 +62,16 @@ const DayStageUnmasking: React.FC<DayStageUnmaskingProps> = ({ playerObject, ref
       .dummyOpUp({
         args: { i: 12 },
       })
-      .send();
-  }
-
-  const startPolling = () => {
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current)
-    }
-    intervalRef.current = setInterval(() => {
-      refresher()
-    }, 2800) // Poll every 2.8 seconds
+      .send()
   }
 
   useEffect(() => {
-    startPolling()
     return () => {
       if (intervalRef.current) {
         clearInterval(intervalRef.current) // Cleanup interval on component unmount
       }
     }
   }, [])
-
 
   return (
     <div>
@@ -103,10 +88,8 @@ const DayStageUnmasking: React.FC<DayStageUnmaskingProps> = ({ playerObject, ref
       ) : (
         <p>Waiting for eliminated player to unmask themselves...</p>
       )}
-
     </div>
   )
-
 }
 
 export default DayStageUnmasking

--- a/projects/mafia-frontend/src/states/GameOver.tsx
+++ b/projects/mafia-frontend/src/states/GameOver.tsx
@@ -2,10 +2,9 @@ import { Player } from '../interfaces/player'
 
 interface GameOverProps {
   playerObject: Player
-  refresher: () => void
 }
 
-const GameOver: React.FC<GameOverProps> = ({ playerObject, refresher }) => {
+const GameOver: React.FC<GameOverProps> = ({ playerObject }) => {
   return <h1>The game is over!</h1>
 }
 

--- a/projects/mafia-frontend/src/states/NightStageDoctorCommit.tsx
+++ b/projects/mafia-frontend/src/states/NightStageDoctorCommit.tsx
@@ -1,16 +1,15 @@
+import algosdk from 'algosdk'
+import { createHash, randomBytes } from 'crypto'
 import { useEffect, useRef, useState } from 'react'
 import { Player } from '../interfaces/player'
-import { createHash, randomBytes } from 'crypto'
-import algosdk from 'algosdk'
-import { ellipseAddress } from '../utils/ellipseAddress'
 import { ZERO_ADDRESS } from '../utils/constants'
+import { ellipseAddress } from '../utils/ellipseAddress'
 
 interface NightStageDoctorCommitProps {
   playerObject: Player
-  refresher: () => void
 }
 
-const NightStageDoctorCommit: React.FC<NightStageDoctorCommitProps> = ({ playerObject, refresher }) => {
+const NightStageDoctorCommit: React.FC<NightStageDoctorCommitProps> = ({ playerObject }) => {
   const [iAmDoctor, setIAmDoctor] = useState<boolean>(false)
   const [potentialPatients, setpotentialPatients] = useState<{ label: string; address: string; number: number }[]>([])
   const intervalRef = useRef<NodeJS.Timeout | null>(null)
@@ -40,9 +39,7 @@ const NightStageDoctorCommit: React.FC<NightStageDoctorCommitProps> = ({ playerO
     if (intervalRef.current) {
       clearInterval(intervalRef.current)
     }
-    intervalRef.current = setInterval(() => {
-      refresher()
-    }, 2800) // Poll every 2.8 seconds
+    intervalRef.current = setInterval(() => {}, 2800) // Poll every 2.8 seconds
   }
 
   useEffect(() => {

--- a/projects/mafia-frontend/src/states/NightStageMafiaCommit.tsx
+++ b/projects/mafia-frontend/src/states/NightStageMafiaCommit.tsx
@@ -1,16 +1,15 @@
+import algosdk from 'algosdk'
+import { createHash, randomBytes } from 'crypto'
 import { useEffect, useRef, useState } from 'react'
 import { Player } from '../interfaces/player'
-import { createHash, randomBytes } from 'crypto'
-import algosdk from 'algosdk'
-import { ellipseAddress } from '../utils/ellipseAddress'
 import { ZERO_ADDRESS } from '../utils/constants'
+import { ellipseAddress } from '../utils/ellipseAddress'
 
 interface NightStageMafiaCommitProps {
   playerObject: Player
-  refresher: () => void
 }
 
-const NightStageMafiaCommit: React.FC<NightStageMafiaCommitProps> = ({ playerObject, refresher }) => {
+const NightStageMafiaCommit: React.FC<NightStageMafiaCommitProps> = ({ playerObject }) => {
   const [iAmMafia, setIAmMafia] = useState<boolean>(false)
   const [potentialVictims, setPotentialVictims] = useState<{ label: string; address: string; number: number }[]>([])
   const [playerIsDead, setPlayerIsDead] = useState<boolean>(false)
@@ -35,7 +34,6 @@ const NightStageMafiaCommit: React.FC<NightStageMafiaCommitProps> = ({ playerObj
         setPlayerIsDead(true)
       }
 
-
       // Filter out the active player and zero addresses
       const validPlayers = fetchedPlayers.filter(
         (player) => player.address !== playerObject.day_algo_address.addr.toString() && player.address !== ZERO_ADDRESS,
@@ -50,9 +48,7 @@ const NightStageMafiaCommit: React.FC<NightStageMafiaCommitProps> = ({ playerObj
     if (intervalRef.current) {
       clearInterval(intervalRef.current)
     }
-    intervalRef.current = setInterval(() => {
-      refresher()
-    }, 2800) // Poll every 2.8 seconds
+    intervalRef.current = setInterval(() => {}, 2800) // Poll every 2.8 seconds
   }
 
   useEffect(() => {

--- a/projects/mafia-frontend/src/states/assignRole.tsx
+++ b/projects/mafia-frontend/src/states/assignRole.tsx
@@ -1,17 +1,16 @@
-import * as algoring from 'algoring-ts'
-import React, { useEffect, useState, useRef } from 'react'
-import { Player } from '../interfaces/player'
-import { useWallet } from '@txnlab/use-wallet-react'
 import { AlgorandClient } from '@algorandfoundation/algokit-utils'
-import { getAlgodConfigFromViteEnvironment, getIndexerConfigFromViteEnvironment } from '../utils/network/getAlgoClientConfigs'
-import { BLS12381G1_LENGTH, RING_SIG_CHALL_LENGTH, RING_SIG_NONCE_LENGTH, ZERO_ADDRESS } from '../utils/constants'
+import { useWallet } from '@txnlab/use-wallet-react'
+import * as algoring from 'algoring-ts'
 import algosdk from 'algosdk'
-import { TownHallClient } from '../contracts/TownHall'
 import assert from 'assert'
+import React, { useEffect, useRef, useState } from 'react'
+import { TownHallClient } from '../contracts/TownHall'
+import { Player } from '../interfaces/player'
+import { BLS12381G1_LENGTH, RING_SIG_CHALL_LENGTH, RING_SIG_NONCE_LENGTH, ZERO_ADDRESS } from '../utils/constants'
+import { getAlgodConfigFromViteEnvironment, getIndexerConfigFromViteEnvironment } from '../utils/network/getAlgoClientConfigs'
 
 interface AssignRoleProps {
   playerObject: Player
-  refresher: () => void
 }
 
 async function prepareLSigRingLink(
@@ -156,7 +155,7 @@ async function assignRoleCall(playerObject: Player) {
   console.log('Assign Role Result:', assignRoleResult)
 }
 
-const AssignRole: React.FC<AssignRoleProps> = ({ playerObject, refresher }) => {
+const AssignRole: React.FC<AssignRoleProps> = ({ playerObject }) => {
   const [playerRole, setPlayerRole] = useState('')
   const intervalRef = useRef<NodeJS.Timeout | null>(null)
   const { activeAddress, transactionSigner } = useWallet()
@@ -185,7 +184,6 @@ const AssignRole: React.FC<AssignRoleProps> = ({ playerObject, refresher }) => {
         grocerAddress !== ZERO_ADDRESS
       ) {
         console.log('All roles have been assigned.')
-        refresher()
       }
 
       if (mafiaAddress && mafiaAddress === playerObject.night_algo_address.addr.toString()) {

--- a/projects/mafia-frontend/src/states/dayStageVote.tsx
+++ b/projects/mafia-frontend/src/states/dayStageVote.tsx
@@ -1,14 +1,13 @@
-import React, { useEffect, useState, useRef } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { Player } from '../interfaces/player'
-import { ellipseAddress } from '../utils/ellipseAddress'
 import { ZERO_ADDRESS } from '../utils/constants'
+import { ellipseAddress } from '../utils/ellipseAddress'
 
 interface DayStageVoteProps {
   playerObject: Player
-  refresher: () => void
 }
 
-const DayStageVote: React.FC<DayStageVoteProps> = ({ playerObject, refresher }) => {
+const DayStageVote: React.FC<DayStageVoteProps> = ({ playerObject }) => {
   const [players, setPlayers] = useState<{ label: string; address: string; number: number }[]>([])
   const [playerHasVoted, setPlayerHasVoted] = useState<boolean>(false)
   const [playerIsDead, setPlayerIsDead] = useState<boolean>(false)
@@ -54,19 +53,9 @@ const DayStageVote: React.FC<DayStageVoteProps> = ({ playerObject, refresher }) 
     }
   }
 
-  const startPolling = () => {
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current)
-    }
-    intervalRef.current = setInterval(() => {
-      refresher()
-    }, 2800) // Poll every 2.8 seconds
-  }
-
   useEffect(() => {
     // Run fetchPlayers initially when the component is loaded
     fetchPlayers()
-    startPolling()
     return () => {
       if (intervalRef.current) {
         clearInterval(intervalRef.current) // Cleanup interval on component unmount

--- a/projects/mafia-frontend/src/states/joinGameLobby.tsx
+++ b/projects/mafia-frontend/src/states/joinGameLobby.tsx
@@ -1,18 +1,17 @@
-import * as algoring from 'algoring-ts'
-import React, { useEffect, useState, useRef } from 'react'
-import { Player } from '../interfaces/player'
-import { useWallet } from '@txnlab/use-wallet-react'
 import { AlgorandClient } from '@algorandfoundation/algokit-utils'
-import { getAlgodConfigFromViteEnvironment, getIndexerConfigFromViteEnvironment } from '../utils/network/getAlgoClientConfigs'
+import { useWallet } from '@txnlab/use-wallet-react'
+import * as algoring from 'algoring-ts'
+import React, { useEffect, useRef, useState } from 'react'
+import { Player } from '../interfaces/player'
 import { BLS12381G1_LENGTH, RING_SIG_NONCE_LENGTH, ZERO_ADDRESS } from '../utils/constants'
 import { ellipseAddress } from '../utils/ellipseAddress'
+import { getAlgodConfigFromViteEnvironment, getIndexerConfigFromViteEnvironment } from '../utils/network/getAlgoClientConfigs'
 
 interface JoinGameLobbyProps {
   playerObject: Player
-  refresher: () => void
 }
 
-const JoinGameLobby: React.FC<JoinGameLobbyProps> = ({ playerObject, refresher }) => {
+const JoinGameLobby: React.FC<JoinGameLobbyProps> = ({ playerObject }) => {
   const [players, setPlayers] = useState<string[]>([])
   const intervalRef = useRef<NodeJS.Timeout | null>(null)
 
@@ -35,7 +34,6 @@ const JoinGameLobby: React.FC<JoinGameLobbyProps> = ({ playerObject, refresher }
 
       if (validPlayers.length === 6) {
         console.log('All players have joined the game.')
-        refresher()
       }
     } catch (error) {
       console.error('Failed to fetch players:', error)
@@ -150,7 +148,6 @@ const JoinGameLobby: React.FC<JoinGameLobbyProps> = ({ playerObject, refresher }
     await fetchPlayers()
     startPolling() // Restart polling after handleJoinGame
   }
-
 
   return (
     <div className="text-center">


### PR DESCRIPTION
# ℹ️ Overview 
This PR addresses the data fetching issues outlined in #6 by replacing the manual refresh pattern with a more efficient solution.
Specifically, it:

- Removes the triggerGameStateFetch pattern and refresher prop drilling throughout the application
- Implements tanstack/use-query to handle gameState fetching with a configurable interval defined in [home.tsx](https://github.com/ericsharma/AlgoMafia/blob/main/projects/mafia-frontend/src/Home.tsx#L55-L61)


## To Do
- [ ] Remove the interval refs from every component and implement a useQuery for [fetchPlayers](https://github.com/HashMapsData2Value/AlgoMafia/blob/a349f8c432526718fae71b2f04d2d0757e3b1aa1/projects/mafia-frontend/src/states/joinGameLobby.tsx#L21-L30) 


